### PR TITLE
Prevent BOverlayNeedsPresent when plugin is loaded on Proton

### DIFF
--- a/src/Source/RuntimeContext.h
+++ b/src/Source/RuntimeContext.h
@@ -283,6 +283,9 @@ class RuntimeContext
 
 		/** Set true if we need to force Corona to render on the next "enterFrame" event. */
 		bool fWasRenderRequested;
+
+		/** Set true if dll is loaded by Proton/Wine. */
+		bool fIsProton;
 };
 
 


### PR DESCRIPTION
Its now implemented to always force a render which has 2 benefits:
- If Proton gets updated and the overlay gets fixed, the force render will make sure things like Notifications will animate properly
- MangoHUD (an FPS counter on SteamDeck) won't show FPS drops because Render will never be skipped