### PR TITLE
Added Steam Inventory functions, to allow item drops to be triggered

### DIFF
--- a/docs/steamworks/destroyInventoryResult.markdown
+++ b/docs/steamworks/destroyInventoryResult.markdown
@@ -1,0 +1,40 @@
+# steamworks.destroyInventoryResult()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Return value__      [Boolean][api.type.Boolean]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, destroyInventoryResult
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.getInventoryResultItems()][plugin.steamworks.getInventoryResultItems]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Destroys an inventory result handle and frees the associated memory. Call this after you finish inspecting a result.
+
+
+## Syntax
+
+	steamworks.destroyInventoryResult( resultHandle )
+
+##### resultHandle ~^(required)^~
+_[Number][api.type.Number]._ Inventory result handle provided by an [inventoryResultReady][plugin.steamworks.event.inventoryResultReady] event.
+
+
+## Example
+
+``````lua
+local steamworks = require( "plugin.steamworks" )
+
+local function onInventoryResultReady( event )
+	if ( not event.isError ) then
+		steamworks.getInventoryResultItems( event.resultHandle )
+	end
+	steamworks.destroyInventoryResult( event.resultHandle )
+end
+
+steamworks.addEventListener( "inventoryResultReady", onInventoryResultReady )
+``````

--- a/docs/steamworks/event/inventoryResultReady/index.markdown
+++ b/docs/steamworks/event/inventoryResultReady/index.markdown
@@ -1,0 +1,50 @@
+# inventoryResultReady
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Event][api.type.event]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, inventoryResultReady
+> __See also__          [steamworks.triggerItemDrop()][plugin.steamworks.triggerItemDrop]
+>                       [steamworks.getInventoryResultItems()][plugin.steamworks.getInventoryResultItems]
+>                       [steamworks.destroyInventoryResult()][plugin.steamworks.destroyInventoryResult]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+Event providing the result of an inventory request such as [steamworks.triggerItemDrop()][plugin.steamworks.triggerItemDrop].
+
+This event can be received by:
+- A listener function passed to [steamworks.triggerItemDrop()][plugin.steamworks.triggerItemDrop].
+- A listener added via [steamworks.addEventListener()][plugin.steamworks.addEventListener].
+
+
+## Properties
+
+#### [event.resultHandle][plugin.steamworks.event.inventoryResultReady.resultHandle]
+
+#### [event.resultCode][plugin.steamworks.event.inventoryResultReady.resultCode]
+
+#### [event.isError][plugin.steamworks.event.inventoryResultReady.isError]
+
+#### [event.name][plugin.steamworks.event.inventoryResultReady.name]
+
+
+## Example
+
+``````lua
+local steamworks = require( "plugin.steamworks" )
+
+local function onInventoryResultReady( event )
+	if ( event.isError ) then
+		print( "Inventory request failed." )
+		return
+	end
+
+	local items = steamworks.getInventoryResultItems( event.resultHandle ) or {}
+	print( "Items returned:", #items )
+	steamworks.destroyInventoryResult( event.resultHandle )
+end
+
+steamworks.addEventListener( "inventoryResultReady", onInventoryResultReady )
+``````

--- a/docs/steamworks/event/inventoryResultReady/isError.markdown
+++ b/docs/steamworks/event/inventoryResultReady/isError.markdown
@@ -1,0 +1,14 @@
+# event.isError
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Boolean][api.type.Boolean]
+> __Event__             [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, inventoryResultReady, isError
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+Set to `true` if the inventory request failed.

--- a/docs/steamworks/event/inventoryResultReady/name.markdown
+++ b/docs/steamworks/event/inventoryResultReady/name.markdown
@@ -1,0 +1,14 @@
+# event.name
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [String][api.type.String]
+> __Event__             [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, inventoryResultReady, name
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+The string value `"inventoryResultReady"`.

--- a/docs/steamworks/event/inventoryResultReady/resultCode.markdown
+++ b/docs/steamworks/event/inventoryResultReady/resultCode.markdown
@@ -1,0 +1,14 @@
+# event.resultCode
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [ResultCode][plugin.steamworks.type.ResultCode]
+> __Event__             [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, inventoryResultReady, resultCode
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+Integer result code returned by Steam for the inventory request.

--- a/docs/steamworks/event/inventoryResultReady/resultHandle.markdown
+++ b/docs/steamworks/event/inventoryResultReady/resultHandle.markdown
@@ -1,0 +1,16 @@
+# event.resultHandle
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Number][api.type.Number]
+> __Event__             [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, inventoryResultReady, resultHandle
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.getInventoryResultItems()][plugin.steamworks.getInventoryResultItems]
+>                       [steamworks.destroyInventoryResult()][plugin.steamworks.destroyInventoryResult]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+The inventory result handle returned by Steam. Use this with [steamworks.getInventoryResultItems()][plugin.steamworks.getInventoryResultItems] and call [steamworks.destroyInventoryResult()][plugin.steamworks.destroyInventoryResult] when finished.

--- a/docs/steamworks/getAllItems.markdown
+++ b/docs/steamworks/getAllItems.markdown
@@ -1,0 +1,47 @@
+# steamworks.getAllItems()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Return value__      [Boolean][api.type.Boolean]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, getAllItems
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.getInventoryResultItems()][plugin.steamworks.getInventoryResultItems]
+>                       [steamworks.destroyInventoryResult()][plugin.steamworks.destroyInventoryResult]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Requests the full inventory for the current user from Steam. The result is delivered via the [inventoryResultReady][plugin.steamworks.event.inventoryResultReady] event.
+
+Returns `true` if the request was successfully sent to Steam. Note that this does not necessarily mean that the requested operation will succeed. Always check the [event.isError][plugin.steamworks.event.inventoryResultReady.isError] field in the received event.
+
+
+## Syntax
+
+	steamworks.getAllItems( [listener] )
+
+##### listener ~^(optional)^~
+_[Function][api.type.Function]._ Listener that receives the [inventoryResultReady][plugin.steamworks.event.inventoryResultReady] event for this request. If omitted, you can receive the event via [steamworks.addEventListener()][plugin.steamworks.addEventListener].
+
+
+## Example
+
+``````lua
+local steamworks = require( "plugin.steamworks" )
+
+local function onInventoryResultReady( event )
+	if ( event.isError ) then
+		print( "GetAllItems failed." )
+		return
+	end
+
+	local items = steamworks.getInventoryResultItems( event.resultHandle ) or {}
+	print( "Inventory item count:", #items )
+	steamworks.destroyInventoryResult( event.resultHandle )
+end
+
+steamworks.getAllItems( onInventoryResultReady )
+``````

--- a/docs/steamworks/getInventoryResultItems.markdown
+++ b/docs/steamworks/getInventoryResultItems.markdown
@@ -1,0 +1,49 @@
+# steamworks.getInventoryResultItems()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Return value__      [Table][api.type.Table]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, getInventoryResultItems
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.destroyInventoryResult()][plugin.steamworks.destroyInventoryResult]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Returns an array of items for the given inventory result handle. Returns `nil` if the handle is invalid or the result is unavailable.
+
+Each array entry is a table with the following fields:
+- `itemDefId` ([Number][api.type.Number])
+- `quantity` ([Number][api.type.Number])
+- `flags` ([Number][api.type.Number])
+- `instanceId` ([String][api.type.String])
+
+
+## Syntax
+
+	steamworks.getInventoryResultItems( resultHandle )
+
+##### resultHandle ~^(required)^~
+_[Number][api.type.Number]._ Inventory result handle provided by an [inventoryResultReady][plugin.steamworks.event.inventoryResultReady] event.
+
+
+## Example
+
+``````lua
+local steamworks = require( "plugin.steamworks" )
+
+local function onInventoryResultReady( event )
+	if ( event.isError ) then
+		return
+	end
+
+	local items = steamworks.getInventoryResultItems( event.resultHandle ) or {}
+	print( "Items in result:", #items )
+	steamworks.destroyInventoryResult( event.resultHandle )
+end
+
+steamworks.addEventListener( "inventoryResultReady", onInventoryResultReady )
+``````

--- a/docs/steamworks/getItemsByID.markdown
+++ b/docs/steamworks/getItemsByID.markdown
@@ -1,0 +1,48 @@
+# steamworks.getItemsByID()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Return value__      [Boolean][api.type.Boolean]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, getItemsByID
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.getInventoryResultItems()][plugin.steamworks.getInventoryResultItems]
+>                       [steamworks.destroyInventoryResult()][plugin.steamworks.destroyInventoryResult]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Requests a subset of inventory items by item instance ID. The result is delivered via the [inventoryResultReady][plugin.steamworks.event.inventoryResultReady] event.
+
+Returns `true` if the request was successfully sent to Steam. Note that this does not necessarily mean that the requested operation will succeed. Always check the [event.isError][plugin.steamworks.event.inventoryResultReady.isError] field in the received event.
+
+
+## Syntax
+
+	steamworks.getItemsByID( itemInstanceIds [, listener] )
+
+##### itemInstanceIds ~^(required)^~
+_[Table][api.type.Table]._ Array of item instance IDs (strings or numbers).
+
+##### listener ~^(optional)^~
+_[Function][api.type.Function]._ Listener that receives the [inventoryResultReady][plugin.steamworks.event.inventoryResultReady] event for this request. If omitted, you can receive the event via [steamworks.addEventListener()][plugin.steamworks.addEventListener].
+
+
+## Example
+
+``````lua
+local steamworks = require( "plugin.steamworks" )
+
+local function onInventoryResultReady( event )
+	if ( event.isError ) then
+		return
+	end
+	local items = steamworks.getInventoryResultItems( event.resultHandle ) or {}
+	print( "Items returned:", #items )
+	steamworks.destroyInventoryResult( event.resultHandle )
+end
+
+steamworks.getItemsByID( { "12345678901234567" }, onInventoryResultReady )
+``````

--- a/docs/steamworks/getResultItemProperty.markdown
+++ b/docs/steamworks/getResultItemProperty.markdown
@@ -1,0 +1,49 @@
+# steamworks.getResultItemProperty()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Return value__      [String][api.type.String]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, getResultItemProperty
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.getInventoryResultItems()][plugin.steamworks.getInventoryResultItems]
+>                       [steamworks.destroyInventoryResult()][plugin.steamworks.destroyInventoryResult]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Returns a string property value for an item within a result set. Pass `nil` for the property name to get a comma-separated list of available properties. Returns `nil` if the property lookup fails.
+
+
+## Syntax
+
+	steamworks.getResultItemProperty( resultHandle, itemIndex [, propertyName] )
+
+##### resultHandle ~^(required)^~
+_[Number][api.type.Number]._ Inventory result handle provided by an [inventoryResultReady][plugin.steamworks.event.inventoryResultReady] event.
+
+##### itemIndex ~^(required)^~
+_[Number][api.type.Number]._ Zero-based index into the result item list.
+
+##### propertyName ~^(optional)^~
+_[String][api.type.String]._ Property name to fetch, or `nil` to return a comma-separated list of available property names.
+
+
+## Example
+
+``````lua
+local steamworks = require( "plugin.steamworks" )
+
+local function onInventoryResultReady( event )
+	if ( event.isError ) then
+		return
+	end
+	local names = steamworks.getResultItemProperty( event.resultHandle, 0, nil )
+	print( "Item properties:", names or "none" )
+	steamworks.destroyInventoryResult( event.resultHandle )
+end
+
+steamworks.getAllItems( onInventoryResultReady )
+``````

--- a/docs/steamworks/index.markdown
+++ b/docs/steamworks/index.markdown
@@ -83,6 +83,18 @@ application =
 
 #### [steamworks.requestActivePlayerCount()][plugin.steamworks.requestActivePlayerCount]
 
+#### [steamworks.triggerItemDrop()][plugin.steamworks.triggerItemDrop]
+
+#### [steamworks.getAllItems()][plugin.steamworks.getAllItems]
+
+#### [steamworks.getItemsByID()][plugin.steamworks.getItemsByID]
+
+#### [steamworks.getInventoryResultItems()][plugin.steamworks.getInventoryResultItems]
+
+#### [steamworks.getResultItemProperty()][plugin.steamworks.getResultItemProperty]
+
+#### [steamworks.destroyInventoryResult()][plugin.steamworks.destroyInventoryResult]
+
 #### [steamworks.requestLeaderboardEntries()][plugin.steamworks.requestLeaderboardEntries]
 
 #### [steamworks.requestLeaderboardInfo()][plugin.steamworks.requestLeaderboardInfo]
@@ -132,6 +144,8 @@ application =
 #### [achievementInfoUpdate][plugin.steamworks.event.achievementInfoUpdate]
 
 #### [activePlayerCount][plugin.steamworks.event.activePlayerCount]
+
+#### [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
 
 #### [leaderboardEntries][plugin.steamworks.event.leaderboardEntries]
 

--- a/docs/steamworks/triggerItemDrop.markdown
+++ b/docs/steamworks/triggerItemDrop.markdown
@@ -1,0 +1,54 @@
+# steamworks.triggerItemDrop()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Return value__      [Boolean][api.type.Boolean]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          steam, steamworks, inventory, drops, triggerItemDrop
+> __See also__          [inventoryResultReady][plugin.steamworks.event.inventoryResultReady]
+>                       [steamworks.getInventoryResultItems()][plugin.steamworks.getInventoryResultItems]
+>                       [steamworks.destroyInventoryResult()][plugin.steamworks.destroyInventoryResult]
+>                       [steamworks.*][plugin.steamworks]
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Requests an inventory drop from Steam using the given drop list definition.
+
+Returns `true` if the request was successfully sent to Steam. Note that this does not necessarily mean that the requested operation will succeed. Always check the [event.isError][plugin.steamworks.event.inventoryResultReady.isError] field in the received [inventoryResultReady][plugin.steamworks.event.inventoryResultReady] event.
+
+
+## Syntax
+
+	steamworks.triggerItemDrop( dropListDefinition [, listener] )
+
+##### dropListDefinition ~^(required)^~
+_[Number][api.type.Number]._ The Steam item definition ID of the drop list to trigger.
+
+##### listener ~^(optional)^~
+_[Function][api.type.Function]._ Listener that receives the [inventoryResultReady][plugin.steamworks.event.inventoryResultReady] event for this request. If omitted, you can receive the event via [steamworks.addEventListener()][plugin.steamworks.addEventListener].
+
+
+## Example
+
+``````lua
+local steamworks = require( "plugin.steamworks" )
+
+local function onInventoryResultReady( event )
+	if ( event.isError ) then
+		print( "Inventory drop failed. Result code: " .. tostring(event.resultCode) )
+		return
+	end
+
+	local items = steamworks.getInventoryResultItems( event.resultHandle ) or {}
+	for i = 1, #items do
+		local item = items[i]
+		print( "Drop item def:", item.itemDefId, "qty:", item.quantity )
+	end
+
+	steamworks.destroyInventoryResult( event.resultHandle )
+end
+
+steamworks.triggerItemDrop( 1000, onInventoryResultReady )
+``````

--- a/src/Source/DispatchEventTask.cpp
+++ b/src/Source/DispatchEventTask.cpp
@@ -624,6 +624,59 @@ bool DispatchMicrotransactionAuthorizationResponseEventTask::PushLuaEventTableTo
 
 
 //---------------------------------------------------------------------------------
+// DispatchInventoryResultReadyEventTask Class Members
+//---------------------------------------------------------------------------------
+
+const char DispatchInventoryResultReadyEventTask::kLuaEventName[] = "inventoryResultReady";
+
+DispatchInventoryResultReadyEventTask::DispatchInventoryResultReadyEventTask()
+:	fResultHandle(k_SteamInventoryResultInvalid),
+	fResultCode(k_EResultFail)
+{
+}
+
+DispatchInventoryResultReadyEventTask::~DispatchInventoryResultReadyEventTask()
+{
+}
+
+void DispatchInventoryResultReadyEventTask::AcquireEventDataFrom(const SteamInventoryResultReady_t& steamEventData)
+{
+	fResultHandle = steamEventData.m_handle;
+	fResultCode = steamEventData.m_result;
+}
+
+const char* DispatchInventoryResultReadyEventTask::GetLuaEventName() const
+{
+	return kLuaEventName;
+}
+
+bool DispatchInventoryResultReadyEventTask::PushLuaEventTableTo(lua_State* luaStatePointer) const
+{
+	// Validate.
+	if (!luaStatePointer)
+	{
+		return false;
+	}
+
+	// Push the event data to Lua.
+	CoronaLuaNewEvent(luaStatePointer, kLuaEventName);
+	{
+		lua_pushinteger(luaStatePointer, fResultHandle);
+		lua_setfield(luaStatePointer, -2, "resultHandle");
+	}
+	{
+		lua_pushboolean(luaStatePointer, (fResultCode != k_EResultOK) ? 1 : 0);
+		lua_setfield(luaStatePointer, -2, "isError");
+	}
+	{
+		lua_pushinteger(luaStatePointer, fResultCode);
+		lua_setfield(luaStatePointer, -2, "resultCode");
+	}
+	return true;
+}
+
+
+//---------------------------------------------------------------------------------
 // DispatchNumberOfCurrentPlayersEventTask Class Members
 //---------------------------------------------------------------------------------
 

--- a/src/Source/DispatchEventTask.h
+++ b/src/Source/DispatchEventTask.h
@@ -209,6 +209,24 @@ class DispatchMicrotransactionAuthorizationResponseEventTask : public BaseDispat
 		uint64_t fOrderId;
 };
 
+/** Dispatches a Steam "SteamInventoryResultReady_t" event and its data to Lua. */
+class DispatchInventoryResultReadyEventTask : public BaseDispatchEventTask
+{
+	public:
+		static const char kLuaEventName[];
+
+		DispatchInventoryResultReadyEventTask();
+		virtual ~DispatchInventoryResultReadyEventTask();
+
+		void AcquireEventDataFrom(const SteamInventoryResultReady_t& steamEventData);
+		virtual const char* GetLuaEventName() const;
+		virtual bool PushLuaEventTableTo(lua_State* luaStatePointer) const;
+
+	private:
+		SteamInventoryResult_t fResultHandle;
+		EResult fResultCode;
+};
+
 
 /** Dispatches a Steam "NumberOfCurrentPlayers_t" event and its data to Lua. */
 class DispatchNumberOfCurrentPlayersEventTask : public BaseDispatchCallResultEventTask

--- a/src/Source/RuntimeContext.cpp
+++ b/src/Source/RuntimeContext.cpp
@@ -98,6 +98,29 @@ void RuntimeContext::AddAuthTicket(HAuthTicket ticket)
 	}
 }
 
+void RuntimeContext::RegisterInventoryResultListener(
+		SteamInventoryResult_t resultHandle,
+		const std::shared_ptr<LuaEventDispatcher>& dispatcherPointer)
+{
+	if ((resultHandle != k_SteamInventoryResultInvalid) && dispatcherPointer)
+	{
+		fInventoryResultDispatcherMap[resultHandle] = dispatcherPointer;
+	}
+}
+
+std::shared_ptr<LuaEventDispatcher> RuntimeContext::RemoveInventoryResultListener(
+		SteamInventoryResult_t resultHandle)
+{
+	auto iterator = fInventoryResultDispatcherMap.find(resultHandle);
+	if (iterator != fInventoryResultDispatcherMap.end())
+	{
+		auto dispatcherPointer = iterator->second;
+		fInventoryResultDispatcherMap.erase(iterator);
+		return dispatcherPointer;
+	}
+	return std::shared_ptr<LuaEventDispatcher>();
+}
+
 std::shared_ptr<LuaEventDispatcher> RuntimeContext::GetLuaEventDispatcher() const
 {
 	return fLuaEventDispatcherPointer;
@@ -367,6 +390,34 @@ void RuntimeContext::OnSteamMicrotransactionAuthorizationReceived(MicroTxnAuthor
 {
 	OnHandleGlobalSteamEvent<
 			MicroTxnAuthorizationResponse_t, DispatchMicrotransactionAuthorizationResponseEventTask>(eventDataPointer);
+}
+
+void RuntimeContext::OnSteamInventoryResultReady(SteamInventoryResultReady_t* eventDataPointer)
+{
+	// Validate.
+	if (!eventDataPointer)
+	{
+		return;
+	}
+
+	// Create and configure the event dispatcher task.
+	auto taskPointer = new DispatchInventoryResultReadyEventTask();
+	if (!taskPointer)
+	{
+		return;
+	}
+
+	// Use a per-request listener if registered; otherwise use the global dispatcher.
+	auto dispatcherPointer = RemoveInventoryResultListener(eventDataPointer->m_handle);
+	if (!dispatcherPointer)
+	{
+		dispatcherPointer = fLuaEventDispatcherPointer;
+	}
+	taskPointer->SetLuaEventDispatcher(dispatcherPointer);
+	taskPointer->AcquireEventDataFrom(*eventDataPointer);
+
+	// Queue the received Steam event data to be dispatched to Lua later.
+	fDispatchEventTaskQueue.push(std::shared_ptr<BaseDispatchEventTask>(taskPointer));
 }
 
 void RuntimeContext::OnSteamPersonaStateChanged(PersonaStateChange_t* eventDataPointer)

--- a/src/Source/RuntimeContext.h
+++ b/src/Source/RuntimeContext.h
@@ -188,6 +188,14 @@ class RuntimeContext
 		/** Adds auth ticket to cancel queue */
 		void AddAuthTicket(HAuthTicket ticket);
 
+		/** Registers a Lua event dispatcher for a pending inventory result handle. */
+		void RegisterInventoryResultListener(
+				SteamInventoryResult_t resultHandle,
+				const std::shared_ptr<LuaEventDispatcher>& dispatcherPointer);
+
+		/** Removes and returns the Lua event dispatcher associated with the given inventory result handle. */
+		std::shared_ptr<LuaEventDispatcher> RemoveInventoryResultListener(SteamInventoryResult_t resultHandle);
+
 	private:
 		/** Copy constructor deleted to prevent it from being called. */
 		RuntimeContext(const RuntimeContext&) = delete;
@@ -238,6 +246,7 @@ class RuntimeContext
 		STEAM_CALLBACK(RuntimeContext, OnSteamGameOverlayActivated, GameOverlayActivated_t);
 		STEAM_CALLBACK(RuntimeContext, OnGetAuthSessionTicketResponse, GetAuthSessionTicketResponse_t);
 		STEAM_CALLBACK(RuntimeContext, OnSteamMicrotransactionAuthorizationReceived, MicroTxnAuthorizationResponse_t);
+		STEAM_CALLBACK(RuntimeContext, OnSteamInventoryResultReady, SteamInventoryResultReady_t);
 		STEAM_CALLBACK(RuntimeContext, OnSteamPersonaStateChanged, PersonaStateChange_t);
 		STEAM_CALLBACK(RuntimeContext, OnSteamUserAchievementIconFetched, UserAchievementIconFetched_t);
 		STEAM_CALLBACK(RuntimeContext, OnSteamUserAchievementStored, UserAchievementStored_t);
@@ -274,6 +283,10 @@ class RuntimeContext
 		  Steam "LeaderboardFindResult_t" event has been received.
 		 */
 		std::unordered_map<std::string, SteamLeaderboard_t> fLeaderboardNameHandleMap;
+
+		/** Maps inventory result handles to their dedicated Lua event dispatchers. */
+		std::unordered_map<SteamInventoryResult_t, std::shared_ptr<LuaEventDispatcher>>
+				fInventoryResultDispatcherMap;
 
 		/** Stores a collection of Steam user IDs (in integer form) that are subscribed to large avatars. */
 		std::unordered_set<uint64> fLargeAvatarSubscribedUserIdSet;

--- a/src/Source/SteamworksLuaInterface.cpp
+++ b/src/Source/SteamworksLuaInterface.cpp
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <string>
 #include <thread>
+#include <vector>
 extern "C"
 {
 #	include "lua.h"
@@ -1236,6 +1237,443 @@ int OnRequestActivePlayerCount(lua_State* luaStatePointer)
 
 	// Return true to Lua if the above async operation was successfully started/executed.
 	lua_pushboolean(luaStatePointer, wasSuccessful ? 1 : 0);
+	return 1;
+}
+
+/** bool steamworks.triggerItemDrop(dropListDefinition, [listener]) */
+int OnTriggerItemDrop(lua_State* luaStatePointer)
+{
+	// Validate.
+	if (!luaStatePointer)
+	{
+		return 0;
+	}
+
+	// Fetch this plugin's runtime context associated with the calling Lua state.
+	auto contextPointer = (RuntimeContext*)lua_touserdata(luaStatePointer, lua_upvalueindex(1));
+	if (!contextPointer)
+	{
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	// Fetch the Steam interface needed by this API call.
+	auto steamInventoryPointer = SteamInventory();
+	if (!steamInventoryPointer)
+	{
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	// Fetch the drop list definition argument.
+	if (lua_type(luaStatePointer, 1) != LUA_TNUMBER)
+	{
+		CoronaLuaError(luaStatePointer, "1st argument must be a numeric 'dropListDefinition'.");
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+	auto dropListDefinition = (SteamItemDef_t)lua_tointeger(luaStatePointer, 1);
+
+	// Fetch the optional listener function.
+	int luaListenerStackIndex = 0;
+	if (lua_gettop(luaStatePointer) >= 2)
+	{
+		if (lua_isfunction(luaStatePointer, 2))
+		{
+			luaListenerStackIndex = 2;
+		}
+		else if (!lua_isnil(luaStatePointer, 2))
+		{
+			CoronaLuaError(luaStatePointer, "2nd argument must be a Lua function or nil.");
+			lua_pushboolean(luaStatePointer, 0);
+			return 1;
+		}
+	}
+
+	// Request a drop from Steam's Inventory service.
+	SteamInventoryResult_t resultHandle = k_SteamInventoryResultInvalid;
+	bool wasSuccessful = steamInventoryPointer->TriggerItemDrop(&resultHandle, dropListDefinition);
+
+	// Register a listener for this request, if provided.
+	if (wasSuccessful && (resultHandle != k_SteamInventoryResultInvalid) && luaListenerStackIndex)
+	{
+		auto luaEventDispatcherPointer = std::make_shared<LuaEventDispatcher>(luaStatePointer);
+		luaEventDispatcherPointer->AddEventListener(
+				luaStatePointer,
+				DispatchInventoryResultReadyEventTask::kLuaEventName,
+				luaListenerStackIndex);
+		contextPointer->RegisterInventoryResultListener(resultHandle, luaEventDispatcherPointer);
+	}
+
+	lua_pushboolean(luaStatePointer, wasSuccessful ? 1 : 0);
+	return 1;
+}
+
+/** bool steamworks.getAllItems([listener]) */
+int OnGetAllItems(lua_State* luaStatePointer)
+{
+	// Validate.
+	if (!luaStatePointer)
+	{
+		return 0;
+	}
+
+	// Fetch this plugin's runtime context associated with the calling Lua state.
+	auto contextPointer = (RuntimeContext*)lua_touserdata(luaStatePointer, lua_upvalueindex(1));
+	if (!contextPointer)
+	{
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	// Fetch the Steam interface needed by this API call.
+	auto steamInventoryPointer = SteamInventory();
+	if (!steamInventoryPointer)
+	{
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	// Fetch the optional listener function.
+	int luaListenerStackIndex = 0;
+	if (lua_gettop(luaStatePointer) >= 1)
+	{
+		if (lua_isfunction(luaStatePointer, 1))
+		{
+			luaListenerStackIndex = 1;
+		}
+		else if (!lua_isnil(luaStatePointer, 1) && (lua_type(luaStatePointer, 1) != LUA_TNONE))
+		{
+			CoronaLuaError(luaStatePointer, "1st argument must be a Lua function or nil.");
+			lua_pushboolean(luaStatePointer, 0);
+			return 1;
+		}
+	}
+
+	// Request all inventory items from Steam.
+	SteamInventoryResult_t resultHandle = k_SteamInventoryResultInvalid;
+	bool wasSuccessful = steamInventoryPointer->GetAllItems(&resultHandle);
+
+	// Register a listener for this request, if provided.
+	if (wasSuccessful && (resultHandle != k_SteamInventoryResultInvalid) && luaListenerStackIndex)
+	{
+		auto luaEventDispatcherPointer = std::make_shared<LuaEventDispatcher>(luaStatePointer);
+		luaEventDispatcherPointer->AddEventListener(
+				luaStatePointer,
+				DispatchInventoryResultReadyEventTask::kLuaEventName,
+				luaListenerStackIndex);
+		contextPointer->RegisterInventoryResultListener(resultHandle, luaEventDispatcherPointer);
+	}
+
+	lua_pushboolean(luaStatePointer, wasSuccessful ? 1 : 0);
+	return 1;
+}
+
+/** bool steamworks.getItemsByID(itemInstanceIds, [listener]) */
+int OnGetItemsByID(lua_State* luaStatePointer)
+{
+	// Validate.
+	if (!luaStatePointer)
+	{
+		return 0;
+	}
+
+	// Fetch this plugin's runtime context associated with the calling Lua state.
+	auto contextPointer = (RuntimeContext*)lua_touserdata(luaStatePointer, lua_upvalueindex(1));
+	if (!contextPointer)
+	{
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	// Fetch the Steam interface needed by this API call.
+	auto steamInventoryPointer = SteamInventory();
+	if (!steamInventoryPointer)
+	{
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	// Fetch the required item instance IDs table argument.
+	if (!lua_istable(luaStatePointer, 1))
+	{
+		CoronaLuaError(luaStatePointer, "1st argument must be a table of item instance IDs.");
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	std::vector<SteamItemInstanceID_t> instanceIds;
+	{
+		lua_pushnil(luaStatePointer);
+		while (lua_next(luaStatePointer, 1) != 0)
+		{
+			SteamItemInstanceID_t nextId = 0;
+			if (lua_type(luaStatePointer, -1) == LUA_TSTRING)
+			{
+				const char* idString = lua_tostring(luaStatePointer, -1);
+				std::stringstream stringStream;
+				stringStream.imbue(std::locale::classic());
+				stringStream << idString;
+				stringStream >> nextId;
+			}
+			else if (lua_type(luaStatePointer, -1) == LUA_TNUMBER)
+			{
+				nextId = (SteamItemInstanceID_t)lua_tointeger(luaStatePointer, -1);
+			}
+			else
+			{
+				CoronaLuaError(luaStatePointer, "Item instance IDs must be strings or numbers.");
+				lua_pop(luaStatePointer, 2);
+				lua_pushboolean(luaStatePointer, 0);
+				return 1;
+			}
+
+			if (nextId != 0)
+			{
+				instanceIds.push_back(nextId);
+			}
+			lua_pop(luaStatePointer, 1);
+		}
+	}
+
+	if (instanceIds.empty())
+	{
+		CoronaLuaError(luaStatePointer, "Item instance IDs table cannot be empty.");
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	// Fetch the optional listener function.
+	int luaListenerStackIndex = 0;
+	if (lua_gettop(luaStatePointer) >= 2)
+	{
+		if (lua_isfunction(luaStatePointer, 2))
+		{
+			luaListenerStackIndex = 2;
+		}
+		else if (!lua_isnil(luaStatePointer, 2))
+		{
+			CoronaLuaError(luaStatePointer, "2nd argument must be a Lua function or nil.");
+			lua_pushboolean(luaStatePointer, 0);
+			return 1;
+		}
+	}
+
+	// Request the items by instance ID.
+	SteamInventoryResult_t resultHandle = k_SteamInventoryResultInvalid;
+	bool wasSuccessful = steamInventoryPointer->GetItemsByID(
+			&resultHandle, instanceIds.data(), (uint32)instanceIds.size());
+
+	// Register a listener for this request, if provided.
+	if (wasSuccessful && (resultHandle != k_SteamInventoryResultInvalid) && luaListenerStackIndex)
+	{
+		auto luaEventDispatcherPointer = std::make_shared<LuaEventDispatcher>(luaStatePointer);
+		luaEventDispatcherPointer->AddEventListener(
+				luaStatePointer,
+				DispatchInventoryResultReadyEventTask::kLuaEventName,
+				luaListenerStackIndex);
+		contextPointer->RegisterInventoryResultListener(resultHandle, luaEventDispatcherPointer);
+	}
+
+	lua_pushboolean(luaStatePointer, wasSuccessful ? 1 : 0);
+	return 1;
+}
+
+/** table steamworks.getInventoryResultItems(resultHandle) */
+int OnGetInventoryResultItems(lua_State* luaStatePointer)
+{
+	// Validate.
+	if (!luaStatePointer)
+	{
+		return 0;
+	}
+
+	// Fetch the result handle argument.
+	if (lua_type(luaStatePointer, 1) != LUA_TNUMBER)
+	{
+		CoronaLuaError(luaStatePointer, "1st argument must be a numeric 'resultHandle'.");
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+	auto resultHandle = (SteamInventoryResult_t)lua_tointeger(luaStatePointer, 1);
+	if (resultHandle == k_SteamInventoryResultInvalid)
+	{
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+
+	// Fetch the Steam interface needed by this API call.
+	auto steamInventoryPointer = SteamInventory();
+	if (!steamInventoryPointer)
+	{
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+
+	// Fetch the item count first.
+	uint32 itemCount = 0;
+	if (!steamInventoryPointer->GetResultItems(resultHandle, nullptr, &itemCount))
+	{
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+
+	std::vector<SteamItemDetails_t> items;
+	if (itemCount > 0)
+	{
+		items.resize(itemCount);
+		if (!steamInventoryPointer->GetResultItems(resultHandle, items.data(), &itemCount))
+		{
+			lua_pushnil(luaStatePointer);
+			return 1;
+		}
+	}
+
+	// Push the items to Lua.
+	lua_createtable(luaStatePointer, (int)itemCount, 0);
+	for (uint32 itemIndex = 0; itemIndex < itemCount; itemIndex++)
+	{
+		lua_createtable(luaStatePointer, 0, 4);
+		{
+			lua_pushinteger(luaStatePointer, items[itemIndex].m_iDefinition);
+			lua_setfield(luaStatePointer, -2, "itemDefId");
+		}
+		{
+			lua_pushinteger(luaStatePointer, items[itemIndex].m_unQuantity);
+			lua_setfield(luaStatePointer, -2, "quantity");
+		}
+		{
+			lua_pushinteger(luaStatePointer, items[itemIndex].m_unFlags);
+			lua_setfield(luaStatePointer, -2, "flags");
+		}
+		{
+			std::stringstream stringStream;
+			stringStream.imbue(std::locale::classic());
+			stringStream << items[itemIndex].m_itemId;
+			auto stringResult = stringStream.str();
+			lua_pushstring(luaStatePointer, stringResult.c_str());
+			lua_setfield(luaStatePointer, -2, "instanceId");
+		}
+		lua_rawseti(luaStatePointer, -2, (int)itemIndex + 1);
+	}
+	return 1;
+}
+
+/** string steamworks.getResultItemProperty(resultHandle, itemIndex, [propertyName]) */
+int OnGetResultItemProperty(lua_State* luaStatePointer)
+{
+	// Validate.
+	if (!luaStatePointer)
+	{
+		return 0;
+	}
+
+	// Fetch the result handle argument.
+	if (lua_type(luaStatePointer, 1) != LUA_TNUMBER)
+	{
+		CoronaLuaError(luaStatePointer, "1st argument must be a numeric 'resultHandle'.");
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+	auto resultHandle = (SteamInventoryResult_t)lua_tointeger(luaStatePointer, 1);
+	if (resultHandle == k_SteamInventoryResultInvalid)
+	{
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+
+	// Fetch the item index argument.
+	if (lua_type(luaStatePointer, 2) != LUA_TNUMBER)
+	{
+		CoronaLuaError(luaStatePointer, "2nd argument must be a numeric 'itemIndex'.");
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+	auto itemIndex = (uint32)lua_tointeger(luaStatePointer, 2);
+
+	// Fetch the optional property name.
+	const char* propertyName = nullptr;
+	if (lua_gettop(luaStatePointer) >= 3)
+	{
+		if (lua_type(luaStatePointer, 3) == LUA_TSTRING)
+		{
+			propertyName = lua_tostring(luaStatePointer, 3);
+		}
+		else if (!lua_isnil(luaStatePointer, 3))
+		{
+			CoronaLuaError(luaStatePointer, "3rd argument must be a string or nil.");
+			lua_pushnil(luaStatePointer);
+			return 1;
+		}
+	}
+
+	// Fetch the Steam interface needed by this API call.
+	auto steamInventoryPointer = SteamInventory();
+	if (!steamInventoryPointer)
+	{
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+
+	// Fetch the value size first, then the value string.
+	uint32 valueBufferSize = 0;
+	if (!steamInventoryPointer->GetResultItemProperty(
+				resultHandle, itemIndex, propertyName, nullptr, &valueBufferSize))
+	{
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+	if (valueBufferSize <= 1)
+	{
+		lua_pushstring(luaStatePointer, "");
+		return 1;
+	}
+
+	std::vector<char> valueBuffer(valueBufferSize);
+	if (!steamInventoryPointer->GetResultItemProperty(
+				resultHandle, itemIndex, propertyName, valueBuffer.data(), &valueBufferSize))
+	{
+		lua_pushnil(luaStatePointer);
+		return 1;
+	}
+
+	lua_pushstring(luaStatePointer, valueBuffer.data());
+	return 1;
+}
+
+/** bool steamworks.destroyInventoryResult(resultHandle) */
+int OnDestroyInventoryResult(lua_State* luaStatePointer)
+{
+	// Validate.
+	if (!luaStatePointer)
+	{
+		return 0;
+	}
+
+	// Fetch the result handle argument.
+	if (lua_type(luaStatePointer, 1) != LUA_TNUMBER)
+	{
+		CoronaLuaError(luaStatePointer, "1st argument must be a numeric 'resultHandle'.");
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+	auto resultHandle = (SteamInventoryResult_t)lua_tointeger(luaStatePointer, 1);
+	if (resultHandle == k_SteamInventoryResultInvalid)
+	{
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	// Fetch the Steam interface needed by this API call.
+	auto steamInventoryPointer = SteamInventory();
+	if (!steamInventoryPointer)
+	{
+		lua_pushboolean(luaStatePointer, 0);
+		return 1;
+	}
+
+	steamInventoryPointer->DestroyResult(resultHandle);
+	lua_pushboolean(luaStatePointer, 1);
 	return 1;
 }
 
@@ -3264,6 +3702,12 @@ CORONA_EXPORT int luaopen_plugin_steamworks(lua_State* luaStatePointer)
 			{ "newImageRect", OnNewImageRect },
 			{ "newTexture", OnNewTexture },
 			{ "requestActivePlayerCount", OnRequestActivePlayerCount },
+			{ "triggerItemDrop", OnTriggerItemDrop },
+			{ "getAllItems", OnGetAllItems },
+			{ "getItemsByID", OnGetItemsByID },
+			{ "getInventoryResultItems", OnGetInventoryResultItems },
+			{ "getResultItemProperty", OnGetResultItemProperty },
+			{ "destroyInventoryResult", OnDestroyInventoryResult },
 			{ "requestLeaderboardEntries", OnRequestLeaderboardEntries },
 			{ "requestLeaderboardInfo", OnRequestLeaderboardInfo },
 			{ "requestSetHighScore", OnRequestSetHighScore },


### PR DESCRIPTION
Added the following Steam Inventory functions, to allow item drops to be triggered and item inventory to be listed: 

steamworks.getAllItems()
steamworks.triggerItemDrop()
steamworks.getInventoryResultItems()
steamworks.destroyInventoryResult()

Note that steamworks.destroyInventoryResult(event. resultHandle) must be called after an onInventoryResultReady callback.